### PR TITLE
Update build number and package dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 05c709c2a074b9e9f5a82065460815ff40bc686286bacfcab5195a69f3ae759b
 
 build:
-  number: 2
+  number: 3
   noarch: python
   entry_points:
     - shiny = shiny._main:main
@@ -28,8 +28,8 @@ requirements:
     - typing-extensions >=4.10.0
     - uvicorn >=0.16.0
     - starlette
-    - websockets >=10.0
-    - python-multipart
+    - websockets >=13.0
+    - python-multipart >=0.0.7
     - htmltools >=0.6.0
     - click >=8.1.4
     - markdown-it-py >=1.1.0
@@ -54,10 +54,7 @@ test:
   imports:
     - shiny
   commands:
-    # Commenting out pip check as it compains about
-    # not finding contextvars (which is only necessary
-    # for python<3.7)
-    # - pip check
+    - pip check
     - shiny --help
     # Assert version isn't 0.0.0
     - python -c "from importlib.metadata import version; assert version('shiny') == '{{ version }}'"


### PR DESCRIPTION
Followup to #75 which had a bad local branch in the py-shiny-feedstock.